### PR TITLE
correct activations for battery.lua file

### DIFF
--- a/sketchybar/items/widgets/battery.lua
+++ b/sketchybar/items/widgets/battery.lua
@@ -74,13 +74,13 @@ battery:subscribe({ "routine", "power_source_change", "system_woke" }, function(
 		if charging then
 			icon = icons.battery.charging
 		else
-			if found and charge > 60 then
+			if found and charge > 75 then
 				icon = ""
 				label = ""
 				drawing = "off"
 				-- icon = icons.battery._100
-				-- elseif found and charge > 60 then
-				-- 	icon = icons.battery._75
+			elseif found and charge < 70 then
+				icon = icons.battery._75
 			elseif found and charge > 50 then
 				icon = icons.battery._50
 				color = colors.yellow


### PR DESCRIPTION
Set's activations for battery icon and makes it a bit more concise and legible.