### PR TITLE
Overhaul tmux config with native popups and cleaner theme

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -6,111 +6,73 @@
 #    ██║   ██║ ╚═╝ ██║╚██████╔╝██╔╝ ██╗
 #    ╚═╝   ╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝
 #
-# Terminal multiplexer
 # https://github.com/tmux/tmux
 
 source-file ~/.config/tmux/tmux.reset.conf
+
+# ── General ────────────────────────────────────────────────────────────
+
 set -g prefix ^s
-set -g base-index 1              # start indexing pane at 1 instead of 0
-set -g pane-base-index 1         # start indexing pane at 1 instead of 0
-set -g detach-on-destroy off     # don't exit from tmux when closing a session
-set -g escape-time 0             # zero-out escape time delay
-set -g history-limit 1000000     # increase history size (from 2,000)
-set -g renumber-windows on       # renumber all windows when any window is closed
-set -g set-clipboard on          # use system clipboard
-set -g mouse on                  # set mouse on
-set -g allow-passthrough on     # for image parsing 
-set -g default-terminal "${TERM}"
+set -g base-index 1
+set -g pane-base-index 1
+set -g detach-on-destroy off
+set -g escape-time 0
+set -g history-limit 1000000
+set -g renumber-windows on
+set -g set-clipboard on
+set -g mouse on
+set -g allow-passthrough on
+set -g extended-keys on
+set -g focus-events on
 setw -g mode-keys vi
-set -g status-position bottom       # macOS / darwin style 
+set -g status-position bottom
 set-option -g default-shell /opt/homebrew/bin/fish
 
-# Instant switch to a new tmux session directory that exist
-unbind -T copy-mode-vi MouseDragEnd1Pane
+# ── Terminal ───────────────────────────────────────────────────────────
 
-# tpm tmux plugin manager
+set -g default-terminal "${TERM}"
+set -as terminal-overrides ',*:Smulx=\E[4::%p1%dm'
+set -as terminal-overrides ',*:Setulc=\E[58::2::%p1%{65536}%/%d::%p1%{256}%/%{255}%&%d::%p1%{255}%&%d%;m'
+set -sa terminal-features ',xterm-256color:RGB'
+
+# ── Plugins ────────────────────────────────────────────────────────────
+
 set-environment -g TMUX_PLUGIN_MANAGER_PATH ~/.tmux/plugins
 set -g @plugin 'tmux-plugins/tpm'
-
-# list of tmux plugins
 set -g @plugin 'catppuccin/tmux'
-set -g @plugin "christoomey/vim-tmux-navigator"
-set -g @plugin 'omerxx/tmux-sessionx' # default keybind "<prefix> o" to activate
-set -g @plugin 'omerxx/tmux-floax' # Floating terminal
+set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'sainnhe/tmux-fzf'
 set -g @plugin 'wfxr/tmux-fzf-url'
 set -g @plugin 'joshmedeski/tmux-nerd-font-window-name'
 
-# floax options
-# Setting the main key to toggle the floating pane on and off
-set -g @floax-bind 't'
-
-# When the pane is toggled, using this bind pops a menu with additional options
-# such as resize, fullscreen, resetting to defaults and more.
-set -g @floax-bind-menu 'T'
-
-# The default width and height of the floating pane
-set -g @floax-width '50%'
-set -g @floax-height '50%'
-
-# The border color can be changed, these are the colors supported by Tmux:
-# black, red, green, yellow, blue, magenta, cyan, white for the standard
-# terminal colors; brightred, brightyellow and so on for the bright variants;
-# colour0/color0 to colour255/color255 for the colors from the 256-color
-# palette; default for the default color; or a hexadecimal RGB color such as #882244.
-set -g @floax-border-color 'gray'
-
-# The text color can also be changed, by default it's blue 
-# to distinguish from the main window
-# Optional colors are as shown above in @floax-border-color
-set -g @floax-text-color 'peach'
-
-# By default when floax sees a change in session path 
-# it'll change the floating pane's path
-# You can disable this by setting it to false
-# You could also "cd -" when the pane is toggled to go back
-set -g @floax-change-path 'true'
-
-# The default session name of the floating pane is 'scratch'
-# You can modify the session name with this option:
-set -g @floax-session-name 'some-other-session-name'
-
-# Change the title of the floating window
-set -g @floax-title 'floax'
-
-# Rebind tmuxsessionx keys to "'"
-set -g @sessionx-bind-zo-new-window 'ctrl-y'
-set -g @sessionx-auto-accept 'off'
-set -g @sessionx-bind "'"
-set -g @sessionx-window-height '50%'
-set -g @sessionx-window-width '50%'
-set -g @sessionx-zoxide-mode 'on'
-set -g @sessionx-custom-paths-subdirectories 'false'
-set -g @sessionx-filter-current 'false'
-
-# Tmux fzf-url-options
 set -g @fzf-url-bind 'x'
 set -g @fzf-url-history-limit '2000'
-
-##### Popups #####
-
-bind c display-popup \
-  -d "#{pane_current_path}" \
-  -w 60% \
-  -h 60% \
-  -E 'claude'
-
-##### Display Menu ##### 
-
-# Other
 set -g @continuum-restore 'on'
 
-# Indicate active pane by colouring only half of the border in windows with 
-# exactly two panes, by displaying arrow markers, by drawing both or neither.
-# [off | colour | arrows | both]
-set -g pane-border-indicators both
+# ── Popups ─────────────────────────────────────────────────────────────
 
+set -g popup-border-style "fg=#{@thm_blue}"
+set -g popup-border-lines rounded
+
+bind c display-popup -d "#{pane_current_path}" -w 60% -h 60% -E 'claude'
+bind C-y display-popup -d "#{pane_current_path}" -w 70% -h 70% -E 'yazi'
+bind C-t display-popup -d "#{pane_current_path}" -w 70% -h 70% -E 'fish'
+bind C-g display-popup -d "#{pane_current_path}" -w 90% -h 90% -E 'lazygit'
+
+# ── Panes ──────────────────────────────────────────────────────────────
+
+set -g pane-border-indicators both
+set -g pane-active-border-style "fg=#{@thm_blue}"
+set -g pane-border-style "fg=#{@thm_surface_0}"
+
+# ── Messages & Selection ───────────────────────────────────────────────
+
+set -g message-style "bg=#{@thm_surface_0},fg=#{@thm_text}"
+set -g message-command-style "bg=#{@thm_surface_0},fg=#{@thm_mauve}"
+set -g mode-style "bg=#{@thm_surface_0},fg=#{@thm_text}"
+
+# ── Theme (catppuccin) ─────────────────────────────────────────────────
 
 # set -g @plugin "adriankarlen/tokyo-night-tmux"
 # set -g @tokyo-night-tmux_theme "rose-pine"
@@ -120,66 +82,44 @@ set -g pane-border-indicators both
 # set -g @tokyo-night-tmux_window_id_style dsquare
 # set -g @tokyo-night-tmux_show_git 0
 
-set -g status-bg default
-set -g status-style bg=default
-
-
-## Theme by 89iuv
-# Configure Catppuccin
 set -g @catppuccin_flavor "mocha"
-set -g @catppuccin_status_background "on"
+set -g @catppuccin_status_background "none"
 set -g @catppuccin_window_status_style "none"
-set -g @catppuccin_pane_status_enabled "on"
+set -g @catppuccin_pane_status_enabled "off"
+set -g @catppuccin_pane_border_status "off"
 
-bg="default"  # transparent
+# ── Status Bar ─────────────────────────────────────────────────────────
 
-  red="#ff657a"
-  maroon="#F29BA7"
-  peach="#ff9b5e"
-  yellow="#eccc81"
-  green="#a8be81"
-  teal="#9cd1bb"
-  sky="#A6C9E5"
-  sapphire="#86AACC"
-  blue="#5d81ab"
-  lavender="#66729C"
-  mauve="#b18eab"
-  text="#fcfcfa"
-  surface2="#535763"
-  surface1="#3a3d4b"
-  surface0="#30303b"
-  base="#202027"
-  mantle="#1c1d22"
-  crust="#171719"
+set -g status-style "bg=#{@thm_bg}"
+set -g status-justify "absolute-centre"
 
-# Status line settings
-set -g status-style "bg=#{bg}"
-set -g status-justify "absolute-centre"  # center status line
-
-# status left style
+# left
 set -g status-left-length 100
 set -g status-left ""
-set -ga status-left "#{?client_prefix,#{#[bg=#{bg},fg=#{red},bold]  #S},#{?pane_in_mode,#{#[bg=#{bg},fg=#{yellow},bold]  #S},#{#[bg=#{bg},fg=#{blue},bold]  #S}}}"
-set -ga status-left "#[bg=#{bg},fg=#{green}]   #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
+set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
 
-# status right style
+# right
 set -g status-right ""
 
-# window style
+# ── Windows ────────────────────────────────────────────────────────────
+
 set -wg automatic-rename on
-set -g window-status-format "#[fg=${mauve},bg=#{bg}] #I:#W#{?window_zoomed_flag, 󰁌 ,}"
-set -g window-status-current-format "#[fg=${peach},bg=#{bg}] #I:#W#{?window_zoomed_flag, 󰁌 ,}"
+set -g automatic-rename-format "#{pane_current_command}"
 
-# pane style
-set -g pane-active-border-style "fg=#{lavender},bg=default"
-set -g pane-border-style "fg=#{surface2},bg=default"
+set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
+set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
+set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
+set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
+set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
 
-# message style
-set -g message-command-style "bg=default,fg=#{mauve}"
-set -g message-style "bg=default,fg=#{mauve}"
+set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
 
-# selection style
-set -g mode-style "bg=#{surface_0},fg=#{teal}"
-set -g @catppuccin_pane_border_status "on"
+# ── TPM (keep at bottom) ──────────────────────────────────────────────
 
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/tmux.reset.conf
+++ b/tmux/tmux.reset.conf
@@ -1,39 +1,69 @@
-# First remove *all* keybindings
-unbind-key -a
-# Now reinsert all the regular tmux keys
-bind ^X lock-server
-bind ^C new-window -c "$HOME"
-bind ^D detach
-bind * list-clients
+# ── Reset ──────────────────────────────────────────────────────────────
 
+unbind-key -a
+
+# ── Session & Client ──────────────────────────────────────────────────
+
+bind ^D detach
+bind ^X lock-server
+bind * list-clients
+bind S choose-session
+bind X kill-session
+
+# ── Windows ───────────────────────────────────────────────────────────
+
+bind ^C new-window -c "$HOME"
+bind ^A last-window
 bind H previous-window
 bind L next-window
-
-bind r command-prompt "rename-window %%"
-bind R source-file ~/.config/tmux/tmux.conf
-bind ^A last-window
 bind W list-windows
-bind z resize-pane -Z
-bind ^L refresh-client
-bind l refresh-client
+bind r command-prompt "rename-window %%"
+bind w kill-pane
+
+# ── Panes ─────────────────────────────────────────────────────────────
+
 bind _ split-window -v -c "#{pane_current_path}"
 bind | split-window -h -c "#{pane_current_path}"
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
+bind z resize-pane -Z
+
 bind -r -T prefix , resize-pane -L 20
 bind -r -T prefix . resize-pane -R 20
 bind -r -T prefix - resize-pane -D 7
 bind -r -T prefix = resize-pane -U 7
-bind : command-prompt
-# bind * setw synchronize-panes
-bind P set pane-border-status
-bind w kill-pane
-bind S choose-session
-bind K send-keys "clear"\; send-keys "Enter"
-bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind X kill-session
 
-bind-key ^K display-popup -h 50% -w 50% -E "sesh picker -id"
-bind-key ^W run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""
+bind P set pane-border-status
+
+# ── Copy Mode ─────────────────────────────────────────────────────────
+
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+
+# ── Misc ──────────────────────────────────────────────────────────────
+
+bind : command-prompt
+bind ^L refresh-client
+bind R source-file ~/.config/tmux/tmux.conf
+bind K send-keys "clear"\; send-keys "Enter"
+
+# ── Sesh ──────────────────────────────────────────────────────────────
+
+bind ^K run-shell "sesh connect \"$(
+        sesh list --icons | fzf-tmux -p 90%,80% \
+        --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
+        --header '🔑 ^a all | ^t tmux | ^g conf | ^x zoxide | ^r rename | ^d tmux kill | ^f find' \
+        --bind 'tab:down,btab:up' \
+        --bind 'ctrl-a:change-prompt(🛸  )+reload(sesh list --icons)' \
+        --bind 'ctrl-t:change-prompt(◧  )+reload(sesh list -t --icons)' \
+        --bind 'ctrl-g:change-prompt(⛯  )+reload(sesh list -c --icons)' \
+        --bind 'ctrl-x:change-prompt(🗃  )+reload(sesh list -z --icons)' \
+        --bind 'ctrl-f:change-prompt(🔭  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+        --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(👽  )+reload(sesh list --icons)' \
+        --preview-window 'right:45%' \
+        --preview 'sesh preview {}'
+)\""
+
+bind ^W run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""


### PR DESCRIPTION
## Summary
- Reorganize `tmux.conf` into logical sections (general, terminal, plugins, popups, panes, theme, windows) and remove inline comments for a cleaner config
- Replace `tmux-floax` and `tmux-sessionx` plugins with native `display-popup` bindings (claude, yazi, lazygit, fish) and a full `sesh` fzf picker
- Switch from hardcoded color hex values to catppuccin theme variables (`@thm_*`), add terminal overrides for undercurl/RGB, and reorganize `tmux.reset.conf` keybindings by category

## Test plan
- [ ] Verify tmux starts cleanly with no errors
- [ ] Test popup bindings: `prefix c` (claude), `prefix C-y` (yazi), `prefix C-t` (fish), `prefix C-g` (lazygit)
- [ ] Test sesh picker via `prefix C-k`
- [ ] Confirm catppuccin theme renders correctly (status bar, pane borders, window tabs)
- [ ] Verify vim-tmux-navigator still works for pane switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)