### PR TITLE
feature/ restore sesh fzf-tmux picker and add root session bindings

### DIFF
--- a/mpv/script-opts/memo-history.log
+++ b/mpv/script-opts/memo-history.log
@@ -31,3 +31,4 @@
 1776100251,40,How I Learn Things Really Fast (with AI),/Users/fox/Videos/To-Watch/How I Learn Things Really Fast (with AI).mp4,126
 1776100328,31,Pondering Over Persona 3 Reload,/Users/fox/Videos/To-Watch/Pondering Over Persona 3 Reload.mp4,108
 1776102117,57,Crash Bandicoot 4: We Saved Video Games | Beyond Pictures,/Users/fox/Videos/Retrospectives/bmask/Crash Bandicoot 4： We Saved Video Games ｜ Beyond Pictures.mp4,176
+1778774257,26,I Can't Hate Psychonauts 2,/Users/fox/Videos/Retrospectives/bmask/I Can't Hate Psychonauts 2.mp4,110

--- a/tmux/tmux.reset.conf
+++ b/tmux/tmux.reset.conf
@@ -50,20 +50,39 @@ bind R source-file ~/.config/tmux/tmux.conf
 
 # ── Sesh ──────────────────────────────────────────────────────────────
 
-# bind ^K run-shell "sesh connect \"$(
-#         sesh list --icons | fzf-tmux -p 90%,80% \
-#         --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
-#         --header '🔑 ^a all | ^t tmux | ^g conf | ^x zoxide | ^r rename | ^d tmux kill | ^f find' \
-#         --bind 'tab:down,btab:up' \
-#         --bind 'ctrl-a:change-prompt(🛸  )+reload(sesh list --icons)' \
-#         --bind 'ctrl-t:change-prompt(◧  )+reload(sesh list -t --icons)' \
-#         --bind 'ctrl-g:change-prompt(⛯  )+reload(sesh list -c --icons)' \
-#         --bind 'ctrl-x:change-prompt(🗃  )+reload(sesh list -z --icons)' \
-#         --bind 'ctrl-f:change-prompt(🔭  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
-#         --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(👽  )+reload(sesh list --icons)' \
-#         --preview-window 'right:45%' \
-#         --preview 'sesh preview {}'
-# )\""
-bind-key ^K display-popup -h 90% -w 50% -E "sesh picker -i"
+bind ^K run-shell "sesh connect \"$(
+        sesh list --icons | fzf-tmux -p 90%,80% \
+        --no-sort --ansi --border-label ' sesh ' --prompt '⚡  ' \
+        --header '🔑 ^a all | ^t tmux | ^g conf | ^x zoxide | ^r rename | ^d tmux kill | ^f find' \
+        --bind 'tab:down,btab:up' \
+        --bind 'ctrl-a:change-prompt(🛸  )+reload(sesh list --icons)' \
+        --bind 'ctrl-t:change-prompt(◧  )+reload(sesh list -t --icons)' \
+        --bind 'ctrl-g:change-prompt(⛯  )+reload(sesh list -c --icons)' \
+        --bind 'ctrl-x:change-prompt(🗃  )+reload(sesh list -z --icons)' \
+        --bind 'ctrl-f:change-prompt(🔭  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+        --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(👽  )+reload(sesh list --icons)' \
+        --preview-window 'right:45%' \
+        --preview 'sesh preview {}'
+)\""
+
+# root sessions
+bind-key "R" run-shell "sesh connect \"\$(
+  sesh list --icons | fzf-tmux -p 100%,100% --no-border \
+    --query  \"\$(sesh root)\" \
+    --list-border \
+    --no-sort --prompt '⚡  ' \
+    --input-border \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-b:abort' \
+    --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -t --icons)' \
+    --bind 'ctrl-g:change-prompt(⚙️  )+reload(sesh list -c --icons)' \
+    --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -z --icons)' \
+    --bind 'ctrl-f:change-prompt(🔎  )+reload(fd -H -d 2 -t d -E .Trash . ~)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+change-prompt(⚡  )+reload(sesh list --icons)' \
+    --preview-window 'right:70%' \
+    --preview 'sesh preview {}' \
+)\""
+
+bind-key "N" display-popup -E "sesh ui"
 bind -N "last-session (via sesh) " ^L run-shell "sesh last"
 bind ^W run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""


### PR DESCRIPTION
## Summary
- Restored the sesh fzf-tmux picker with full keybinding support (replaced the simplified `sesh picker -i` popup)
- Added `R` binding for root session selection via fzf-tmux with full-screen layout
- Added `N` binding to launch the sesh UI via display-popup
- Updated mpv watch history

## Test plan
- [ ] Verify `^K` opens fzf-tmux sesh picker with all keybinds working
- [ ] Verify `R` opens root session picker in full-screen mode
- [ ] Verify `N` opens sesh UI popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)