### PR TITLE
feat(sketchybar): add yabai space interactions and misc config updates

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -82,6 +82,7 @@ abbr sr "sesh root"
 
 # System Commands
 abbr pwdc "pwd | pbcopy"
+abbr --add - 'cd -'
 
 # Tmux
 abbr tn "tmux new-session -s"

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -58,7 +58,7 @@ bell_on_tab           no
 #: }}}
 
 # Kitty cursor colors
-# cursor #fab387
+cursor #89dceb
 
 # Close child processes on parent death
 close_on_child_death yes

--- a/kitty/quick-access-terminal-center.conf
+++ b/kitty/quick-access-terminal-center.conf
@@ -1,0 +1,4 @@
+edge center-sized
+lines 22
+columns 75
+background_opacity 0.85

--- a/nvim/lua/plugins/markview.lua
+++ b/nvim/lua/plugins/markview.lua
@@ -1,7 +1,7 @@
 return {
   "OXY2DEV/markview.nvim",
   lazy = false,
-  enabled = false,
+  enabled = true,
   opts = {
     html = {
       enable = true,

--- a/nvim/lua/plugins/render-markdown.lua
+++ b/nvim/lua/plugins/render-markdown.lua
@@ -4,7 +4,7 @@ return {
   ---@module 'render-markdown'
   ---@type render.md.UserConfig
 
-  enabled = true,
+  enabled = false,
 
   config = function()
     require("render-markdown").setup({

--- a/sketchybar/items/cpu.lua
+++ b/sketchybar/items/cpu.lua
@@ -43,15 +43,15 @@ function mod.setup(bar, palette)
 			padding_right = 0,
 			y_offset = -(bar.config.height / 2) + graph_margin + 8,
 
-			icon = {
-				string = "􀅺 ",
-				drawing = true,
-				color = palette.text.subtle,
-				width = ICON_WIDTH,
-				padding_left = 0,
-				padding_right = 0,
-				font = { family = config.font, style = "Regular", size = 10.0 },
-			},
+			-- icon = {
+			-- 	string = "",
+			-- 	drawing = true,
+			-- 	color = palette.text.subtle,
+			-- 	width = ICON_WIDTH,
+			-- 	padding_left = 0,
+			-- 	padding_right = 0,
+			-- 	font = { family = config.font, style = "Regular", size = 10.0 },
+			-- },
 
 			label = {
 				string = "0%",
@@ -120,8 +120,8 @@ function mod.load(separator, palette)
 			mod.graph_label:set({ drawing = true })
 			separator:set({
 				icon = {
-					string = "􀅺",
-					font = { family = config.font, style = "Regular", size = 11.0 },
+					string = "􀫰",
+					font = { family = config.font, style = "Semibold", size = 14.0 },
 					padding_left = 4,
 					padding_right = 4,
 					y_offset = 0,

--- a/sketchybar/items/spaces.lua
+++ b/sketchybar/items/spaces.lua
@@ -216,9 +216,15 @@ local function yabaiSpaceChange(item)
 	end
 end
 
-local function yabaiClick()
+local function yabaiClick(item, space_popup)
 	return function(env)
-		sbar.exec("yabai -m space --focus " .. env.SID)
+		if env.BUTTON == "other" then
+			space_popup:set({ background = { image = "space." .. env.SID } })
+			item:set({ popup = { drawing = "toggle" } })
+		else
+			local op = (env.BUTTON == "right") and "--destroy" or "--focus"
+			sbar.exec("yabai -m space " .. op .. " " .. env.SID)
+		end
 	end
 end
 
@@ -245,13 +251,33 @@ local function loadYabaiSpaces(zones)
 		mod.items[i] = item
 		zones.brackets.spaces[i] = item
 
+		local space_popup = sbar.add("item", {
+			position = "popup." .. item.name,
+			padding_left = 5,
+			padding_right = 0,
+			background = {
+				drawing = true,
+				image = {
+					corner_radius = 9,
+					scale = 0.10,
+				},
+			},
+		})
+
 		item:subscribe("space_change", yabaiSpaceChange(item))
 		item:subscribe("space_windows_change", yabaiWindowChange(item, i))
-		item:subscribe("mouse.clicked", yabaiClick())
+		item:subscribe("mouse.clicked", yabaiClick(item, space_popup))
 		item:subscribe("mouse.entered", yabaiMouseHover(item))
+		item:subscribe("mouse.exited", function(_)
+			item:set({ popup = { drawing = false } })
+		end)
 	end
 
 	mod.items["separator"] = sbar.add("item", mod.properties.separator)
+	mod.items["separator"]:subscribe("mouse.clicked", function(_)
+		sbar.exec("yabai -m space --create")
+	end)
+
 	mod.items["front_app"] = sbar.add("item", mod.properties.front_app)
 
 	mod.items["front_app"]:subscribe("front_app_switched", function(env)

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,7 +37,7 @@ set -ga terminal-overrides ",*256col*:Tc"
 
 set-environment -g TMUX_PLUGIN_MANAGER_PATH ~/.tmux/plugins
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'catppuccin/tmux'
+set -g @plugin 'omerxx/catppuccin-tmux' # My fork that holds the meetings script bc I'm lazy af
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'sainnhe/tmux-fzf'
@@ -70,52 +70,63 @@ set -g mode-style "bg=#{@thm_surface_0},fg=#{@thm_text}"
 
 # ── Theme (catppuccin) ─────────────────────────────────────────────────
 
-# set -g @plugin "adriankarlen/tokyo-night-tmux"
-# set -g @tokyo-night-tmux_theme "rose-pine"
-# set -g @tokyo-night-tmux_show_datetime 0
-# set -g @tokyo-night-tmux_show_path 1
-# set -g @tokyo-night-tmux_path_format relative
-# set -g @tokyo-night-tmux_window_id_style dsquare
-# set -g @tokyo-night-tmux_show_git 0
-
-set -g @catppuccin_flavor "mocha"
-set -g @catppuccin_status_background "none"
-set -g @catppuccin_window_status_style "none"
-set -g @catppuccin_pane_status_enabled "off"
-set -g @catppuccin_pane_border_status "off"
+set -g @catppuccin_flavor 'mocha'
+# set -g @catppuccin_status_background "none"
+# set -g @catppuccin_window_status_style "none"
+# set -g @catppuccin_pane_status_enabled "off"
+# set -g @catppuccin_pane_border_status "off"
 
 # ── Status Bar ─────────────────────────────────────────────────────────
 
-set -g status-style "bg=#{@thm_bg}"
-set -g status-justify "absolute-centre"
-
-# left
-set -g status-left-length 100
-set -g status-left ""
-set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
-set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
-set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
-set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
-set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
-
-# right
-set -g status-right ""
-
-# ── Windows ────────────────────────────────────────────────────────────
-
+# set -g status-style "bg=#{@thm_bg}"
+# set -g status-justify "absolute-centre"
+#
+# # left
+# set -g status-left-length 100
+# set -g status-left ""
+# set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
+# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
+# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
+# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
+# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
+#
+# # right
+# set -g status-right ""
+#
+# # ── Windows ────────────────────────────────────────────────────────────
+#
 set -wg automatic-rename on
 set -g automatic-rename-format "#{pane_current_command}"
+#
+# set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+# set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
+# set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
+# set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
+# set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
+# set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
+#
+# set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+# set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
 
-set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
-set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
-set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
-set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
-set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
-set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
-
-set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
-set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
-
+set -g pane-active-border-style 'fg=magenta,bg=default'
+set -g pane-border-style 'bg=default'
+set -g @catppuccin_window_left_separator ""
+set -g @catppuccin_window_right_separator " "
+set -g @catppuccin_window_middle_separator " █"
+set -g @catppuccin_window_number_position "right"
+set -g @catppuccin_window_default_fill "number"
+set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_current_fill "number"
+set -g @catppuccin_window_current_text "#W#{?window_zoomed_flag,( ),}"
+set -g @catppuccin_status_modules_right "directory" # date_time"
+set -g @catppuccin_status_modules_left "session"
+set -g @catppuccin_status_left_separator  " "
+set -g @catppuccin_status_right_separator " "
+set -g @catppuccin_status_right_separator_inverse "no"
+set -g @catppuccin_status_fill "icon"
+set -g @catppuccin_status_connect_separator "no"
+set -g @catppuccin_directory_text "#{b:pane_current_path}"
+set -g @catppuccin_directory_text "#{b:pane_current_path}"
 # ── TPM (keep at bottom) ──────────────────────────────────────────────
 
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

- **sketchybar/spaces**: Implement yabai space interactions — middle-click shows a scaled thumbnail popup of the space, right-click destroys the space, clicking the separator arrow creates a new space
- **sketchybar/cpu**: Update CPU icon to use a different SF Symbol with Semibold weight
- **tmux**: Switch to `omerxx/catppuccin-tmux` fork and update theme configuration to use the fork's style variables
- **nvim**: Swap active markdown renderer — enable `markview.nvim`, disable `render-markdown`
- **kitty**: Change cursor colour to `#89dceb` and add quick-access-terminal-center config
- **fish**: Add `cd -` abbreviation for navigating to the previous directory

## Test plan

- [ ] Middle-click a yabai space pill — thumbnail popup should appear at ~10% scale
- [ ] Right-click a yabai space pill — space should be destroyed via yabai
- [ ] Click the separator `􀯻` arrow — a new space should be created
- [ ] Moving the mouse off a space pill should dismiss any open popup
- [ ] Tmux status bar renders correctly with the omerxx fork theme
- [ ] Markview renders markdown in nvim; render-markdown is inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)