### PR TITLE
Update herdr config and plugins, ignore auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@
 
 # Ignore mpv cache files
 mpv/cache/
+
+# Ignore herdr auto-generated cache files
+herdr/release-notes.json
+
+# Ignore herdr plugin installer temporary directories
+herdr/plugins/.tmp-install-*/

--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -19,6 +19,7 @@ name = "terminal"
 # red = "#ff6188"
 # green = "#a6e3a1"
 
+auto_switch = false
 [terminal]
 # Executable used for new interactive panes.
 # Empty means $SHELL, then /bin/sh.

--- a/herdr/plugins.json
+++ b/herdr/plugins.json
@@ -1,207 +1,5 @@
 [
   {
-    "plugin_id": "cloudmanic.herdr-plus",
-    "name": "Herdr Plus",
-    "version": "0.1.10",
-    "min_herdr_version": "0.7.0",
-    "description": "An extension for herdr — a collection of tools that make it better. Projects: fuzzy-pick a declarative template to spin up a whole workspace — every tab, pane, and startup command. Quick Actions: a fuzzy launcher for one-off scripts, run in the directory you launched from.",
-    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9/herdr-plugin.toml",
-    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9",
-    "enabled": true,
-    "platforms": [
-      "linux",
-      "macos"
-    ],
-    "build": [
-      {
-        "command": [
-          "sh",
-          "scripts/build.sh"
-        ]
-      }
-    ],
-    "actions": [
-      {
-        "id": "ping",
-        "title": "Herdr Plus: ping",
-        "command": [
-          "./bin/herdr-plus",
-          "ping"
-        ]
-      },
-      {
-        "id": "projects",
-        "title": "Herdr Plus: Projects",
-        "command": [
-          "./bin/herdr-plus",
-          "projects"
-        ]
-      },
-      {
-        "id": "quick-actions",
-        "title": "Herdr Plus: Quick Actions",
-        "command": [
-          "./bin/herdr-plus",
-          "quick-actions"
-        ]
-      }
-    ],
-    "events": [
-      {
-        "on": "worktree.created",
-        "command": [
-          "./bin/herdr-plus",
-          "on-worktree"
-        ]
-      },
-      {
-        "on": "worktree.opened",
-        "command": [
-          "./bin/herdr-plus",
-          "on-worktree"
-        ]
-      }
-    ],
-    "panes": [
-      {
-        "id": "picker",
-        "title": "Herdr Plus: Projects",
-        "placement": "zoomed",
-        "command": [
-          "./bin/herdr-plus",
-          "projects-ui"
-        ]
-      },
-      {
-        "id": "quick-actions-picker",
-        "title": "Quick Actions",
-        "placement": "overlay",
-        "command": [
-          "./bin/herdr-plus",
-          "quick-actions-ui"
-        ]
-      }
-    ],
-    "source": {
-      "kind": "github",
-      "owner": "cloudmanic",
-      "repo": "herdr-plus",
-      "resolved_commit": "013fe1667a638487004164955a01707584ab7b9e",
-      "managed_path": "/Users/fox/.config/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9",
-      "installed_unix_ms": 1782923147832
-    }
-  },
-  {
-    "plugin_id": "herdr-picker-plus",
-    "name": "Picker Plus",
-    "version": "0.2.0",
-    "min_herdr_version": "0.7.0",
-    "description": "Move anywhere in your Herdr workflow: search workspaces, SSH servers, agents, projects, actions, directories, and plugin integrations from one native picker.",
-    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/herdr-picker-plus-24891de4026e/herdr-plugin.toml",
-    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/herdr-picker-plus-24891de4026e",
-    "enabled": true,
-    "platforms": [
-      "linux",
-      "macos"
-    ],
-    "build": [
-      {
-        "command": [
-          "cargo",
-          "build",
-          "--release"
-        ]
-      }
-    ],
-    "actions": [
-      {
-        "id": "open",
-        "title": "Picker Plus: open",
-        "contexts": [
-          "workspace",
-          "global"
-        ],
-        "command": [
-          "./target/release/herdr-picker-plus",
-          "open"
-        ]
-      }
-    ],
-    "panes": [
-      {
-        "id": "picker",
-        "title": "Picker Plus",
-        "placement": "overlay",
-        "command": [
-          "./target/release/herdr-picker-plus",
-          "ui"
-        ]
-      }
-    ],
-    "source": {
-      "kind": "github",
-      "owner": "thanhdat77",
-      "repo": "herdr-picker-plus",
-      "resolved_commit": "1dfdeb7c64307a529a6ccae2e39d1caf02446b2d",
-      "managed_path": "/Users/fox/.config/herdr/plugins/github/herdr-picker-plus-24891de4026e",
-      "installed_unix_ms": 1782923254525
-    }
-  },
-  {
-    "plugin_id": "url.fzf-picker",
-    "name": "FZF URL Picker",
-    "version": "0.1.0",
-    "min_herdr_version": "0.7.0",
-    "description": "Scan terminal panes for URLs and interactively pick one with fzf",
-    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c/herdr-plugin.toml",
-    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c",
-    "enabled": true,
-    "platforms": [
-      "linux",
-      "macos"
-    ],
-    "build": [
-      {
-        "command": [
-          "go",
-          "build",
-          "-o",
-          "herdr-fzf-url"
-        ]
-      }
-    ],
-    "actions": [
-      {
-        "id": "pick-url",
-        "title": "Pick URL from Panes",
-        "contexts": [
-          "pane"
-        ],
-        "command": [
-          "./herdr-fzf-url"
-        ]
-      }
-    ],
-    "panes": [
-      {
-        "id": "url-picker",
-        "title": "URL Picker",
-        "placement": "overlay",
-        "command": [
-          "./herdr-fzf-url"
-        ]
-      }
-    ],
-    "source": {
-      "kind": "github",
-      "owner": "x0d7x",
-      "repo": "herdr-fzf-url",
-      "resolved_commit": "7f5fc52a4367c537cae11b636bb27bc26e2279ad",
-      "managed_path": "/Users/fox/.config/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c",
-      "installed_unix_ms": 1782923307350
-    }
-  },
-  {
     "plugin_id": "rjyo.window-title-sync",
     "name": "Window Title Sync",
     "version": "0.1.0",
@@ -318,6 +116,208 @@
     }
   },
   {
+    "plugin_id": "cloudmanic.herdr-plus",
+    "name": "Herdr Plus",
+    "version": "0.1.16",
+    "min_herdr_version": "0.7.0",
+    "description": "An extension for herdr — a collection of tools that make it better. Projects: fuzzy-pick a declarative template to spin up a whole workspace — every tab, pane, and startup command. Quick Actions: a fuzzy launcher for one-off scripts, run in the directory you launched from.",
+    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9/herdr-plugin.toml",
+    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos"
+    ],
+    "build": [
+      {
+        "command": [
+          "sh",
+          "scripts/build.sh"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "ping",
+        "title": "Herdr Plus: ping",
+        "command": [
+          "./bin/herdr-plus",
+          "ping"
+        ]
+      },
+      {
+        "id": "projects",
+        "title": "Herdr Plus: Projects",
+        "command": [
+          "./bin/herdr-plus",
+          "projects"
+        ]
+      },
+      {
+        "id": "quick-actions",
+        "title": "Herdr Plus: Quick Actions",
+        "command": [
+          "./bin/herdr-plus",
+          "quick-actions"
+        ]
+      }
+    ],
+    "events": [
+      {
+        "on": "worktree.created",
+        "command": [
+          "./bin/herdr-plus",
+          "on-worktree"
+        ]
+      },
+      {
+        "on": "worktree.opened",
+        "command": [
+          "./bin/herdr-plus",
+          "on-worktree"
+        ]
+      }
+    ],
+    "panes": [
+      {
+        "id": "picker",
+        "title": "Herdr Plus: Projects",
+        "placement": "zoomed",
+        "command": [
+          "./bin/herdr-plus",
+          "projects-ui"
+        ]
+      },
+      {
+        "id": "quick-actions-picker",
+        "title": "Quick Actions",
+        "placement": "overlay",
+        "command": [
+          "./bin/herdr-plus",
+          "quick-actions-ui"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "cloudmanic",
+      "repo": "herdr-plus",
+      "resolved_commit": "f32b0825f12543c1d03e54fb10d1741c40d66cdc",
+      "managed_path": "/Users/fox/.config/herdr/plugins/github/cloudmanic.herdr-plus-0cce37b56fb9",
+      "installed_unix_ms": 1783424108223
+    }
+  },
+  {
+    "plugin_id": "herdr-picker-plus",
+    "name": "Picker Plus",
+    "version": "0.2.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Move anywhere in your Herdr workflow: search workspaces, SSH servers, agents, projects, actions, directories, and plugin integrations from one native picker.",
+    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/herdr-picker-plus-24891de4026e/herdr-plugin.toml",
+    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/herdr-picker-plus-24891de4026e",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos"
+    ],
+    "build": [
+      {
+        "command": [
+          "cargo",
+          "build",
+          "--release"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "open",
+        "title": "Picker Plus: open",
+        "contexts": [
+          "workspace",
+          "global"
+        ],
+        "command": [
+          "./target/release/herdr-picker-plus",
+          "open"
+        ]
+      }
+    ],
+    "panes": [
+      {
+        "id": "picker",
+        "title": "Picker Plus",
+        "placement": "overlay",
+        "command": [
+          "./target/release/herdr-picker-plus",
+          "ui"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "thanhdat77",
+      "repo": "herdr-picker-plus",
+      "resolved_commit": "1dfdeb7c64307a529a6ccae2e39d1caf02446b2d",
+      "managed_path": "/Users/fox/.config/herdr/plugins/github/herdr-picker-plus-24891de4026e",
+      "installed_unix_ms": 1782923254525
+    }
+  },
+  {
+    "plugin_id": "url.fzf-picker",
+    "name": "FZF URL Picker",
+    "version": "0.1.0",
+    "min_herdr_version": "0.7.0",
+    "description": "Scan terminal panes for URLs and interactively pick one with fzf",
+    "manifest_path": "/Users/fox/.dotfiles/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c/herdr-plugin.toml",
+    "plugin_root": "/Users/fox/.dotfiles/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c",
+    "enabled": true,
+    "platforms": [
+      "linux",
+      "macos"
+    ],
+    "build": [
+      {
+        "command": [
+          "go",
+          "build",
+          "-o",
+          "herdr-fzf-url"
+        ]
+      }
+    ],
+    "actions": [
+      {
+        "id": "pick-url",
+        "title": "Pick URL from Panes",
+        "contexts": [
+          "pane"
+        ],
+        "command": [
+          "./herdr-fzf-url"
+        ]
+      }
+    ],
+    "panes": [
+      {
+        "id": "url-picker",
+        "title": "URL Picker",
+        "placement": "overlay",
+        "command": [
+          "./herdr-fzf-url"
+        ]
+      }
+    ],
+    "source": {
+      "kind": "github",
+      "owner": "x0d7x",
+      "repo": "herdr-fzf-url",
+      "resolved_commit": "7f5fc52a4367c537cae11b636bb27bc26e2279ad",
+      "managed_path": "/Users/fox/.config/herdr/plugins/github/url.fzf-picker-bbe028f7cf4c",
+      "installed_unix_ms": 1782923307350
+    }
+  },
+  {
     "plugin_id": "herdr-floax",
     "name": "herdr-floax",
     "version": "0.2.0",
@@ -366,7 +366,7 @@
       "repo": "herdr-floax",
       "resolved_commit": "5bf869ab666c45a3a72af88c2a92b413f05f2c56",
       "managed_path": "/Users/fox/.config/herdr/plugins/github/herdr-floax-0151ef56c880",
-      "installed_unix_ms": 1783307624093
+      "installed_unix_ms": 1783423985277
     }
   }
 ]

--- a/herdr/plugins/config/cloudmanic.herdr-plus/quick-actions/77/camera-switch.toml/72/72/ camera-switch.toml
+++ b/herdr/plugins/config/cloudmanic.herdr-plus/quick-actions/77/camera-switch.toml/72/72/ camera-switch.toml
@@ -1,3 +1,0 @@
-name = "📜 Cam Switch Input" 
-description = "Switch camera" 
-command = "~/.config/scripts/choose/cam.sh"


### PR DESCRIPTION
## Summary
- Bump herdr-plus plugin version and add `auto_switch = false` config option
- Remove a stale/corrupted camera-switch quick action file
- Bump the cloudmanic.herdr-plus submodule pointer
- Ignore herdr's auto-generated release notes cache and plugin-installer temp directories in .gitignore

## Test plan
- [x] Restart herdr and confirm plugins load with no errors
- [x] Confirm `auto_switch` behaves as expected in herdr/config.toml
- [x] Confirm quick actions list no longer shows the removed camera-switch entry