### PR TITLE
Switch kitty theme to mocha

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -38,7 +38,7 @@ cursor_trail 1
 # Window padding
 window_padding_width 10
 
-include ./themes/catppuccin_frappe.conf
+include ./themes/catppuccin_mocha.conf
 
 # Set transparent background and blur background
 background_opacity 0.60


### PR DESCRIPTION
## Summary
- Switch kitty's included theme from `catppuccin_frappe.conf` to `catppuccin_mocha.conf`

## Test plan
- [x] Reload kitty config and confirm mocha theme colors apply