### PR TITLE
Update nvim colorscheme settings and enable relative line numbers

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -42,7 +42,7 @@ vim.api.nvim_create_autocmd({ "BufEnter", "WinEnter" }, {
 vim.api.nvim_set_hl(0, "FloatBorder", { link = "Normal" })
 
 -- line numbers
-opt.relativenumber = false -- show relative line numbers
+opt.relativenumber = true -- show relative line numbers
 opt.number = true -- shows absolute line number on cursor line (when relative number is on)
 
 -- tabs & indentation

--- a/nvim/lua/plugins/colorschemes/catppuccin.lua
+++ b/nvim/lua/plugins/colorschemes/catppuccin.lua
@@ -12,9 +12,9 @@ local palette = {
   mauve = "#b18eab",
 }
 
--- local palette = function(value)
---   return vim.tbl_extend("force", palette, value)
--- end
+local palette = function(value)
+  return vim.tbl_extend("force", palette, value)
+end
 
 -- colorscheme == catppuccin
 return {
@@ -32,7 +32,7 @@ return {
     lazy = false,
     priority = 1000,
     opts = {
-      flavour = "mocha", -- Latte, Frappe, Macchiato, Mocha
+      flavour = "frappe", -- Latte, Frappe, Macchiato, Mocha
       no_italic = false,
       term_colors = true,
       transparent_background = true,
@@ -50,31 +50,31 @@ return {
         types = {},
       },
       color_overrides = {
-        -- frappe = palette({
-        --   text = "#fcfcfa",
-        --   surface2 = "#535763",
-        --   surface1 = "#3a3d4b",
-        --   surface0 = "#30303b",
-        --   base = "#202027",
-        --   mantle = "#1c1d22",
-        --   crust = "#171719",
-        -- }),
-        -- latte = palette({
-        --   text = "#202027",
-        --   subtext1 = "#263168",
-        --   subtext0 = "#4c4f69",
-        --   overlay2 = "#737994",
-        --   overlay1 = "#838ba7",
-        --   base = "#fcfcfa",
-        --   mantle = "#EAEDF3",
-        --   crust = "#DCE0E8",
-        --   pink = "#EA7A95",
-        --   mauve = "#986794",
-        --   red = "#EC5E66",
-        --   peach = "#FF8459",
-        --   yellow = "#CAA75E",
-        --   green = "#87A35E",
-        -- }),
+        frappe = palette({
+          text = "#fcfcfa",
+          surface2 = "#535763",
+          surface1 = "#3a3d4b",
+          surface0 = "#30303b",
+          base = "#202027",
+          mantle = "#1c1d22",
+          crust = "#171719",
+        }),
+        latte = palette({
+          text = "#202027",
+          subtext1 = "#263168",
+          subtext0 = "#4c4f69",
+          overlay2 = "#737994",
+          overlay1 = "#838ba7",
+          base = "#fcfcfa",
+          mantle = "#EAEDF3",
+          crust = "#DCE0E8",
+          pink = "#EA7A95",
+          mauve = "#986794",
+          red = "#EC5E66",
+          peach = "#FF8459",
+          yellow = "#CAA75E",
+          green = "#87A35E",
+        }),
         mocha = {
           text = "#fcfcfa",
           surface2 = "#535763",
@@ -105,12 +105,18 @@ return {
             BlinkCmpMenuSelection = { fg = mocha.base, bg = mocha.blue },
           }
         end,
-        -- frappe = function(frappe)
-        --   return {
-        --     IblScope = { fg = frappe.none, style = { "bold" } },
-        --     BlinkCmpMenuSelection = { fg = frappe.base, bg = frappe.teal },
-        --   }
-        -- end,
+        frappe = function(frappe)
+          return {
+            IblScope = { fg = frappe.none, style = { "bold" } },
+            BlinkCmpMenuSelection = { fg = frappe.base, bg = frappe.blue },
+          }
+        end,
+        latte = function(latte)
+          return {
+            IblScope = { fg = latte.none, style = { "bold" } },
+            BlinkCmpMenuSelection = { fg = latte.base, bg = latte.green },
+          }
+        end,
       },
     },
   },

--- a/nvim/lua/plugins/colorschemes/rose-pine.lua
+++ b/nvim/lua/plugins/colorschemes/rose-pine.lua
@@ -89,14 +89,14 @@ return {
 
       before_highlight = function(group, highlight, palette)
         -- Disable all undercurls
-        -- if highlight.undercurl then
-        --     highlight.undercurl = false
-        -- end
+        if highlight.undercurl then
+          highlight.undercurl = false
+        end
         --
         -- Change palette colour
-        -- if highlight.fg == palette.pine then
-        --     highlight.fg = palette.foam
-        -- end
+        if highlight.fg == palette.pine then
+          highlight.fg = palette.foam
+        end
       end,
     })
 


### PR DESCRIPTION
## Summary
- Enable `relativenumber` in nvim options
- Re-enable frappe/latte color_overrides and highlight groups in the catppuccin config, switch default flavour to frappe
- Re-enable the undercurl-disable and palette fg-swap tweaks in rose-pine's `before_highlight`

## Test plan
- [ ] Open nvim and confirm relative line numbers show
- [ ] Switch to frappe/latte/mocha colorschemes and confirm palette overrides look correct
- [ ] Switch to rose-pine and confirm undercurls are disabled and highlight colors look right