### PR TITLE
Switch cmd+return back to wezterm

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/skhd/skhdrc
+++ b/skhd/skhdrc
@@ -10,9 +10,9 @@ alt - n : $HOME/.dotfiles/wezterm/open_floating_notes.sh
 alt - t : $HOME/.dotfiles/wezterm/open_scratchpad.sh
 
 # Applications
-# rcmd - return : open -n -a "wezterm"
+rcmd - return : open -n -a "wezterm"
 # rcmd - return : open -n -a "ghostty"
-rcmd - return : open -n -a "kitty"
+# rcmd - return : open -n -a "kitty"
 
 # change layout of desktop
 lctrl + alt - b : yabai -m space --layout bsp


### PR DESCRIPTION
## Summary
- Re-enable the `rcmd - return` shortcut to launch wezterm
- Comment out the equivalent kitty launch shortcut

## Test plan
- [ ] Press cmd+return and confirm wezterm opens instead of kitty