### PR TITLE
Rework tmux status bar styling

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,7 +37,6 @@ set -ga terminal-overrides ",*256col*:Tc"
 
 set-environment -g TMUX_PLUGIN_MANAGER_PATH ~/.tmux/plugins
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'omerxx/catppuccin-tmux' # My fork that holds the meetings script bc I'm lazy af
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'sainnhe/tmux-fzf'
@@ -69,7 +68,6 @@ set -g message-command-style "bg=#{@thm_surface_0},fg=#{@thm_mauve}"
 set -g mode-style "bg=#{@thm_surface_0},fg=#{@thm_text}"
 
 # ── Theme (catppuccin) ─────────────────────────────────────────────────
-
 set -g @catppuccin_flavor 'mocha'
 # set -g @catppuccin_status_background "none"
 # set -g @catppuccin_window_status_style "none"
@@ -78,55 +76,55 @@ set -g @catppuccin_flavor 'mocha'
 
 # ── Status Bar ─────────────────────────────────────────────────────────
 
-# set -g status-style "bg=#{@thm_bg}"
-# set -g status-justify "absolute-centre"
+set -g status-style "bg=#{@thm_bg}"
+set -g status-justify "absolute-centre"
 #
 # # left
-# set -g status-left-length 100
-# set -g status-left ""
-# set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
-# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
-# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
-# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
-# set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
+set -g status-left-length 100
+set -g status-left ""
+set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
+set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
 #
 # # right
-# set -g status-right ""
+set -g status-right ""
 #
 # # ── Windows ────────────────────────────────────────────────────────────
 #
 set -wg automatic-rename on
 set -g automatic-rename-format "#{pane_current_command}"
 #
-# set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
-# set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
-# set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
-# set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
-# set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
-# set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
-#
-# set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
-# set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
+set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
+set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
+set -g window-status-activity-style "bg=#{@thm_red},fg=#{@thm_bg}"
+set -g window-status-bell-style "bg=#{@thm_red},fg=#{@thm_bg},bold"
+set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
+
+set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
+set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
 
 set -g pane-active-border-style 'fg=magenta,bg=default'
 set -g pane-border-style 'bg=default'
-set -g @catppuccin_window_left_separator ""
-set -g @catppuccin_window_right_separator " "
-set -g @catppuccin_window_middle_separator " █"
-set -g @catppuccin_window_number_position "right"
-set -g @catppuccin_window_default_fill "number"
-set -g @catppuccin_window_default_text "#W"
-set -g @catppuccin_window_current_fill "number"
-set -g @catppuccin_window_current_text "#W#{?window_zoomed_flag,( ),}"
-set -g @catppuccin_status_modules_right "directory" # date_time"
-set -g @catppuccin_status_modules_left "session"
-set -g @catppuccin_status_left_separator  " "
-set -g @catppuccin_status_right_separator " "
-set -g @catppuccin_status_right_separator_inverse "no"
-set -g @catppuccin_status_fill "icon"
-set -g @catppuccin_status_connect_separator "no"
-set -g @catppuccin_directory_text "#{b:pane_current_path}"
-set -g @catppuccin_directory_text "#{b:pane_current_path}"
+# set -g @catppuccin_window_left_separator ""
+# set -g @catppuccin_window_right_separator " "
+# set -g @catppuccin_window_middle_separator " █"
+# set -g @catppuccin_window_number_position "right"
+# set -g @catppuccin_window_default_fill "number"
+# set -g @catppuccin_window_default_text "#W"
+# set -g @catppuccin_window_current_fill "number"
+# set -g @catppuccin_window_current_text "#W#{?window_zoomed_flag,( ),}"
+# set -g @catppuccin_status_modules_right "directory" # date_time"
+# set -g @catppuccin_status_modules_left "session"
+# set -g @catppuccin_status_left_separator  " "
+# set -g @catppuccin_status_right_separator " "
+# set -g @catppuccin_status_right_separator_inverse "no"
+# set -g @catppuccin_status_fill "icon"
+# set -g @catppuccin_status_connect_separator "no"
+# set -g @catppuccin_directory_text "#{b:pane_current_path}"
+# set -g @catppuccin_directory_text "#{b:pane_current_path}"
 # ── TPM (keep at bottom) ──────────────────────────────────────────────
 
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Drop the `omerxx/catppuccin-tmux` plugin dependency
- Re-enable a hand-rolled status-bar styling block (status-style, status-left/right, window-status formats/styles) as a replacement
- Comment out the now-unused `@catppuccin_window_*` / `@catppuccin_status_*` settings

## Test plan
- [ ] Reload tmux config and confirm the status bar renders correctly without the catppuccin-tmux plugin