### PR TITLE
Update starship config: refine vim-mode symbols, enable directory truncation, simplify palette

### DIFF
--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -23,6 +23,7 @@ abbr bs "brew search"
 
 # Claude
 abbr ca claude
+abbr cc claude --dangerously-skip-permissions
 
 # Espanso
 abbr ee "espanso edit"

--- a/starship.toml
+++ b/starship.toml
@@ -32,15 +32,15 @@ palette = "catppuccin_frappe"
 disabled = false
 success_symbol = "[ ](bold fg:text)"
 error_symbol = "[✘](red bold)"
-vimcmd_symbol = "[ ](bold fg:maroon)"
-vimcmd_replace_one_symbol = '[󰜉 ](bold fg:sapphire)'
+vimcmd_symbol = "[: ](bold fg:yellow)"
+vimcmd_replace_one_symbol = '[󰜉 ](bold fg:maroon)'
 vimcmd_visual_symbol = '[􀋭 ](bold fg:sapphire)'
 # ---
 
 [directory]
 style = 'blue'
 truncation_length = 10
-# truncation_symbol = '…/  '
+truncation_symbol = '…/  '
 home_symbol = '~'
 read_only_style = '197'
 read_only = '  '
@@ -152,28 +152,7 @@ disabled = false
 
 # Display OS symbol at the very begining
 [os]
-format = '[$symbol](bold grey)'
 disabled = true 
-
-[os.symbols]
-Windows = "󰍲"
-Ubuntu = "󰕈"
-SUSE = ""
-Raspbian = "󰐿"
-Mint = "󰣭"
-Macos = ""
-Manjaro = ""
-Linux = "󰌽"
-Gentoo = "󰣨"
-Fedora = "󰣛"
-Alpine = ""
-Amazon = ""
-Android = ""
-Arch = "󰣇"
-Artix = "󰣇"
-CentOS = ""
-Debian = "󰣚"
-Redhat = "󱄛"
 
 [aws]
 disabled = true
@@ -196,7 +175,9 @@ format = "[ $symbol( $context) ]($style)"
 symbol = '󱃾 '
 format = "[ $symbol( $context) ]($style)"
 
-[palettes.catppuccin_kopicat]
+# ---- P A L E T T E S ----
+
+[palettes.kopicat]
 red = "#ff657a"
 maroon = "#F29BA7"
 rose_pink = "#ebbcba"


### PR DESCRIPTION
## Summary
- Refine vim-mode cmd symbols/colors
- Enable directory truncation_symbol
- Remove the `[os]` format line and unused `[os.symbols]` block (os module stays disabled)
- Rename `[palettes.catppuccin_kopicat]` to `[palettes.kopicat]`

## Test plan
- [ ] Reload starship prompt and confirm vim-mode symbols and directory truncation look correct
- [ ] Confirm the kopicat palette still resolves correctly under its new name