### PR TITLE
zsh/starship: mocha palette + deja autosuggestions

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,6 +1,6 @@
 # Starship ----------------------------------------
 eval "$(starship init zsh)"
-export STARSHIP_CONFIG=~/.config/starship/starship.toml
+export STARSHIP_CONFIG=~/.config/starship.toml
 
 # Install Homebrew -------------------------------
 if [[ -f "/opt/homebrew/bin/brew" ]] then
@@ -22,8 +22,10 @@ source "${ZINIT_HOME}/zinit.zsh"
 
 # Add in zsh plugins
 zinit light zsh-users/zsh-syntax-highlighting
-zinit light zsh-users/zsh-completions
-zinit light zsh-users/zsh-autosuggestions
+# zinit light zsh-users/zsh-completions
+# zinit light zsh-users/zsh-autosuggestions
+zinit ice wait"0" lucid depth=1
+zinit light Giammarco-Ferranti/deja
 zinit light Aloxaf/fzf-tab
 zinit light jeffreytse/zsh-vi-mode
 zinit load atuinsh/atuin
@@ -261,3 +263,7 @@ chruby ruby-3.4.1
 # eval "$(atuin init zsh)"
 
 export PATH=$PATH:/Users/fox/.spicetify
+eval "$(deja init zsh)"
+
+fpath=(/Users/fox/.zsh/completions $fpath)
+autoload -Uz compinit && compinit

--- a/starship.toml
+++ b/starship.toml
@@ -26,11 +26,12 @@ $git_metrics\
 
 right_format = """$aws$python$docker_context$terraform"""
 
-palette = "catppuccin_frappe"
+palette = "catppuccin_mocha"
 
 [character]
 disabled = false
 success_symbol = "[ ](bold fg:text)"
+# success_symbol = "[󰌪 ](bold fg:green)"
 error_symbol = "[✘](red bold)"
 vimcmd_symbol = "[: ](bold fg:yellow)"
 vimcmd_replace_one_symbol = '[󰜉 ](bold fg:maroon)'
@@ -40,7 +41,7 @@ vimcmd_visual_symbol = '[􀋭 ](bold fg:sapphire)'
 [directory]
 style = 'blue'
 truncation_length = 10
-truncation_symbol = '…/  '
+# truncation_symbol = '…/  '
 home_symbol = '~'
 read_only_style = '197'
 read_only = '  '
@@ -95,7 +96,7 @@ ignore_timeout = true
 
 # Shows current git branch
 [git_branch]
-symbol = "[](black) "
+symbol = "[](black) "
 format =  ' on [$symbol$branch]($style)[](black)'
 truncation_symbol = '…/'
 style = 'fg:lavender bg:black'
@@ -152,6 +153,7 @@ disabled = false
 
 # Display OS symbol at the very begining
 [os]
+format = '[$symbol](bold grey)'
 disabled = true 
 
 [aws]
@@ -174,8 +176,6 @@ format = "[ $symbol( $context) ]($style)"
 [kubernetes]
 symbol = '󱃾 '
 format = "[ $symbol( $context) ]($style)"
-
-# ---- P A L E T T E S ----
 
 [palettes.kopicat]
 red = "#ff657a"


### PR DESCRIPTION
Switches `STARSHIP_CONFIG` to the flattened path, replaces zsh-users completions/autosuggestions with `deja`, autoloads custom completions, and moves the starship palette from frappe to mocha.