### PR TITLE
kitty: switch theme to rose-pine

### DIFF
--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -38,7 +38,7 @@ cursor_trail 1
 # Window padding
 window_padding_width 10
 
-include ./themes/catppuccin_frappe.conf
+include ./themes/rose-pine.conf
 
 # Set transparent background and blur background
 background_opacity 0.60


### PR DESCRIPTION
Points the kitty theme include at `themes/rose-pine.conf` instead of catppuccin frappe.