### PR TITLE
sketchybar: fix control-center click + selected space label

### DIFF
--- a/sketchybar/items/controls.lua
+++ b/sketchybar/items/controls.lua
@@ -33,9 +33,22 @@ end
 function mod.load()
 	local item = sbar.add("item", mod.properties.control_center)
 	item:subscribe("mouse.clicked", function(env)
-		sbar.exec(
-			'osascript -e \'tell application "System Events" to tell process "ControlCenter" to click menu bar item 4 of menu bar 1\''
-		)
+		sbar.exec([[osascript -e '
+			tell application "System Events"
+				tell process "MenuBarAgent"
+					repeat with g in every group of menu bar 1
+						repeat with theItem in every menu bar item of g
+							try
+								if (value of attribute "AXIdentifier" of theItem) is "com.apple.menuextra.controlcenter" then
+									click theItem
+									return
+								end if
+							end try
+						end repeat
+					end repeat
+				end tell
+			end tell
+		']])
 	end)
 
 	mod.control_center = item

--- a/sketchybar/items/notifs.lua
+++ b/sketchybar/items/notifs.lua
@@ -2,58 +2,60 @@ local mod = {}
 
 -- Setup
 function mod.setup(icons, palette)
-  mod.properties = {
-    position = "right",
+	mod.properties = {
+		position = "right",
 
-    update_freq = 1800,
+		update_freq = 1800,
 
-    icon = { 
-      color = palette.colors.blue,
-      string = icons.notifications.empty
-    },
-    
-    label = { string = "0" }
-  }
+		icon = {
+			color = palette.colors.blue,
+			string = icons.notifications.empty,
+		},
 
-  return mod
+		label = { string = "0" },
+	}
+
+	return mod
 end
 
-local function update(item,key_path,icons,palette)
-  return function (env) 
-    sbar.exec([[
+local function update(item, key_path, icons, palette)
+	return function(env)
+		sbar.exec([[
       curl -m 15 -s \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $(cat "]] .. key_path ..  [[")" \
+        -H "Authorization: Bearer $(cat "]] .. key_path .. [[")" \
         https://api.github.com/notifications
-    ]], function (result,exit_code) 
-      if exit_code ~= 0 or result.status == 401 then 
-        log("notif","[error] code: " .. tostring(exit_code) .. ", result: " .. dump(result))
-        return
-      end
+    ]], function(result, exit_code)
+			if exit_code ~= 0 or result.status == 401 then
+				log("notif", "[error] code: " .. tostring(exit_code) .. ", result: " .. dump(result))
+				return
+			end
 
-      local count = 0
-      for _,_ in pairs(result) do count = count + 1 end
-      
-      item:set({ 
-        label = { string = tostring(count) }, 
-        icon = (count > 0) and { color = palette.colors.red , string = icons.notifications.notif } 
-                            or { color = palette.colors.blue, string = icons.notifications.empty } 
-      })
-    end)
-  end
+			local count = 0
+			for _, _ in pairs(result) do
+				count = count + 1
+			end
+
+			item:set({
+				label = { string = tostring(count) },
+				icon = (count > 0) and { color = palette.colors.red, string = icons.notifications.notif }
+					or { color = palette.colors.blue, string = icons.notifications.empty },
+			})
+		end)
+	end
 end
 
 -- Load
-function mod.load(icons,palette)
-  if config.git_key then 
-    mod.item = sbar.add("item",mod.properties)
-    mod.item:subscribe({"routine","forced"}, update(mod.item,config.git_key,icons,palette))
-    mod.item:subscribe("mouse.clicked", function ()
-      sbar.exec("open https://github.com/notifications")
-    end)
-  end
+function mod.load(icons, palette)
+	if config.git_key then
+		mod.item = sbar.add("item", mod.properties)
+		mod.item:subscribe({ "routine", "forced" }, update(mod.item, config.git_key, icons, palette))
+		mod.item:subscribe("mouse.clicked", function()
+			sbar.exec("open https://github.com/notifications")
+		end)
+	end
 
-  return mod
+	return mod
 end
 
 return mod

--- a/sketchybar/items/spaces.lua
+++ b/sketchybar/items/spaces.lua
@@ -176,7 +176,7 @@ local function yabaiWindowChange(item, space_index)
 			sequencedAnimation(item, "tanh", 15, {
 				label = { string = icon_strip },
 			}, {
-				label = { width = "dynamic" },
+				label = { width = (not item.state.selected) and "dynamic" or 0 },
 			}, nil, true)
 
 			if not item.state.selected then


### PR DESCRIPTION
Fixes the control-center click AppleScript to target the `MenuBarAgent` process, collapses a selected space's label width to 0, and reindents notifs.lua to tabs (no logic change).