### PR TITLE
tmux: omp popup, remapped reset keys, nerd-font window icons

### DIFF
--- a/tmux/tmux-nerd-font-window-name.yml
+++ b/tmux/tmux-nerd-font-window-name.yml
@@ -1,0 +1,13 @@
+config:
+  fallback-icon: "?" # show when no definition is found
+  multi-pane-icon: "" # show when window has multiple panes (blank by default)
+  show-name: true # show the window name with the icon (defaults to false)
+  always-show-fallback-name: false # always show the name alongside the fallback icon, even when show-name is false (defaults to false)
+  icon-position: "left" # show the icon to the "left" or "right" of the window name (defaults to left)
+
+icons:
+  cmatrix: "🤯" # add new entries that aren't included
+  omp: " "
+  claude: "󱜚 "
+  2.1.220: "󱜚 "
+  fish: ""

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -37,6 +37,7 @@ set -ga terminal-overrides ",*256col*:Tc"
 
 set-environment -g TMUX_PLUGIN_MANAGER_PATH ~/.tmux/plugins
 set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'sainnhe/tmux-fzf'
@@ -47,10 +48,10 @@ set -g @fzf-url-history-limit '2000'
 set -g @fzf-url-fzf-options '-p 60%,30% --prompt="   " --border-label=" Open URL "'
 # ── Popups ─────────────────────────────────────────────────────────────
 
-set -g popup-border-style "fg=#{@thm_blue}"
+set -g popup-border-style "fg=#{@thm_red}"
 set -g popup-border-lines rounded
 
-bind c display-popup -d "#{pane_current_path}" -w 60% -h 60% -E 'claude'
+bind o display-popup -d "#{pane_current_path}" -w 60% -h 60% -E 'omp'
 bind C-y display-popup -d "#{pane_current_path}" -w 70% -h 70% -E 'yazi'
 bind C-t display-popup -d "#{pane_current_path}" -w 70% -h 70% -E 'fish'
 bind C-g display-popup -d "#{pane_current_path}" -w 90% -h 90% -E 'lazygit'
@@ -68,18 +69,27 @@ set -g message-command-style "bg=#{@thm_surface_0},fg=#{@thm_mauve}"
 set -g mode-style "bg=#{@thm_surface_0},fg=#{@thm_text}"
 
 # ── Theme (catppuccin) ─────────────────────────────────────────────────
-set -g @catppuccin_flavor 'mocha'
-# set -g @catppuccin_status_background "none"
-# set -g @catppuccin_window_status_style "none"
-# set -g @catppuccin_pane_status_enabled "off"
-# set -g @catppuccin_pane_border_status "off"
+
+# set -g @plugin "adriankarlen/tokyo-night-tmux"
+# set -g @tokyo-night-tmux_theme "rose-pine"
+# set -g @tokyo-night-tmux_show_datetime 0
+# set -g @tokyo-night-tmux_show_path 1
+# set -g @tokyo-night-tmux_path_format relative
+# set -g @tokyo-night-tmux_window_id_style dsquare
+# set -g @tokyo-night-tmux_show_git 0
+
+set -g @catppuccin_flavor "mocha"
+set -g @catppuccin_status_background "none"
+set -g @catppuccin_window_status_style "none"
+set -g @catppuccin_pane_status_enabled "off"
+set -g @catppuccin_pane_border_status "off"
 
 # ── Status Bar ─────────────────────────────────────────────────────────
 
 set -g status-style "bg=#{@thm_bg}"
 set -g status-justify "absolute-centre"
-#
-# # left
+
+# left
 set -g status-left-length 100
 set -g status-left ""
 set -ga status-left "#{?client_prefix,#{#[bg=#{@thm_red},fg=#{@thm_bg},bold]  #S },#{#[bg=#{@thm_bg},fg=#{@thm_green}]  #S }}"
@@ -87,15 +97,15 @@ set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]│"
 set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_blue}]  #{=/-32/...:#{s|$USER|~|:#{b:pane_current_path}}} "
 set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_overlay_0},none]#{?window_zoomed_flag,│,}"
 set -ga status-left "#[bg=#{@thm_bg},fg=#{@thm_yellow}]#{?window_zoomed_flag,  zoom ,}"
-#
-# # right
+
+# right
 set -g status-right ""
-#
-# # ── Windows ────────────────────────────────────────────────────────────
-#
+
+# ── Windows ────────────────────────────────────────────────────────────
+
 set -wg automatic-rename on
 set -g automatic-rename-format "#{pane_current_command}"
-#
+
 set -g window-status-format " #I#{?#{!=:#{window_name},Window},: #W,} "
 set -g window-status-style "bg=#{@thm_bg},fg=#{@thm_overlay_0}"
 set -g window-status-last-style "bg=#{@thm_bg},fg=#{@thm_overlay_1}"
@@ -106,25 +116,6 @@ set -gF window-status-separator "#[bg=#{@thm_bg},fg=#{@thm_overlay_0}]│"
 set -g window-status-current-format " #I#{?#{!=:#{window_name},Window},: #W,} "
 set -g window-status-current-style "bg=#{@thm_blue},fg=#{@thm_bg},bold"
 
-set -g pane-active-border-style 'fg=magenta,bg=default'
-set -g pane-border-style 'bg=default'
-# set -g @catppuccin_window_left_separator ""
-# set -g @catppuccin_window_right_separator " "
-# set -g @catppuccin_window_middle_separator " █"
-# set -g @catppuccin_window_number_position "right"
-# set -g @catppuccin_window_default_fill "number"
-# set -g @catppuccin_window_default_text "#W"
-# set -g @catppuccin_window_current_fill "number"
-# set -g @catppuccin_window_current_text "#W#{?window_zoomed_flag,( ),}"
-# set -g @catppuccin_status_modules_right "directory" # date_time"
-# set -g @catppuccin_status_modules_left "session"
-# set -g @catppuccin_status_left_separator  " "
-# set -g @catppuccin_status_right_separator " "
-# set -g @catppuccin_status_right_separator_inverse "no"
-# set -g @catppuccin_status_fill "icon"
-# set -g @catppuccin_status_connect_separator "no"
-# set -g @catppuccin_directory_text "#{b:pane_current_path}"
-# set -g @catppuccin_directory_text "#{b:pane_current_path}"
 # ── TPM (keep at bottom) ──────────────────────────────────────────────
 
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux/tmux.reset.conf
+++ b/tmux/tmux.reset.conf
@@ -4,7 +4,7 @@ unbind-key -a
 
 # ── Session & Client ──────────────────────────────────────────────────
 
-bind ^D detach
+bind d detach
 bind ^X lock-server
 bind * list-clients
 bind S choose-session
@@ -14,16 +14,16 @@ bind X kill-session
 
 bind ^C new-window -c "$HOME"
 bind ^A last-window
-bind H previous-window
-bind L next-window
+bind p previous-window
+bind n next-window
 bind W list-windows
 bind r command-prompt "rename-window %%"
 bind w kill-pane
 
 # ── Panes ─────────────────────────────────────────────────────────────
 
-bind _ split-window -v -c "#{pane_current_path}"
-bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+bind \\ split-window -h -c "#{pane_current_path}"
 bind h select-pane -L
 bind j select-pane -D
 bind k select-pane -U
@@ -32,16 +32,18 @@ bind z resize-pane -Z
 
 bind -r -T prefix , resize-pane -L 20
 bind -r -T prefix . resize-pane -R 20
-bind -r -T prefix - resize-pane -D 7
+bind -r -T prefix _ resize-pane -D 7
 bind -r -T prefix = resize-pane -U 7
 
 bind P set pane-border-status
 
 # ── Copy Mode ─────────────────────────────────────────────────────────
 
-bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+# bind-key -T copy-mode-vi v send-keys -X begin-selection
+# bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 
+bind Escape copy-mode
+bind-key -T copy-mode-vi v send-keys -X begin-selection
 # ── Misc ──────────────────────────────────────────────────────────────
 
 bind : command-prompt
@@ -65,6 +67,6 @@ bind ^K run-shell "sesh connect \"$(
         --preview 'sesh preview {}'
 )\""
 
-bind-key ";" display-popup -h 50% -w 50% -E "sesh picker -idHs"
-bind -N "last-session (via sesh) " ^L run-shell "sesh last"
+bind-key ";" display-popup -h 50% -w 50% -E "sesh picker -ds"
+# bind ^N "last-session (via sesh) " ^L run-shell "sesh last"
 bind ^W run-shell "sesh window \"$(sesh window | fzf-tmux -p 60%,50% --prompt '🪟  ')\""


### PR DESCRIPTION
Adds the catppuccin/tmux plugin and repoints its overrides, rebinds the prefix+c popup from `claude` to `omp`, remaps several keys in tmux.reset.conf (detach, prev/next window, resize, sesh picker), and adds `tmux-nerd-font-window-name.yml` icon mappings.