### PR TITLE
sketchybar: fix github notifs, rework as open-PR badge

### DIFF
--- a/sketchybar/init.lua
+++ b/sketchybar/init.lua
@@ -34,6 +34,9 @@ config = fetchConfig(os.getenv("SKETCHYBAR_CONFIG") or "./config.lua", { -- Look
 	cpu_update_freq = 2,
 	perfbc = true, -- Allow command bundling for improved performance
 	git_key = nil,
+	git_api_url = "https://api.github.com", -- override for GHE/homelab, e.g. "https://git.home.lab/api/v3"
+	git_web_url = "https://github.com", -- override to match git_api_url's host for self-hosted instances
+	git_pr_query = "is:pr is:open author:@me", -- GitHub search qualifiers, see docs.github.com/search-syntax
 	display_groups = {},
 	execs = {}, -- Overrides for executables
 })

--- a/sketchybar/items/notifs.lua
+++ b/sketchybar/items/notifs.lua
@@ -18,30 +18,57 @@ function mod.setup(icons, palette)
 	return mod
 end
 
-local function update(item, key_path, icons, palette)
-	return function(env)
-		sbar.exec([[
+-- Builds a GitHub search-API command for `query` against config.git_api_url/git_key.
+-- Works against github.com and GitHub Enterprise/homelab instances alike, since both
+-- expose `GET <api_url>/search/issues?q=...`. SbarLua auto-decodes JSON responses into
+-- a Lua table, so the callback receives `{ total_count = N, items = {...} }` directly.
+local function search_command(key_path, query)
+	return string.format(
+		[[
       curl -m 15 -s \
         -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $(cat "]] .. key_path .. [[")" \
-        https://api.github.com/notifications
-    ]], function(result, exit_code)
-			if exit_code ~= 0 or result.status == 401 then
-				log("notif", "[error] code: " .. tostring(exit_code) .. ", result: " .. dump(result))
+        -H "Authorization: Bearer $(cat "%s")" \
+        "%s/search/issues?q=%s&per_page=1"
+    ]],
+		key_path,
+		config.git_api_url,
+		query:gsub(" ", "+")
+	)
+end
+
+local function set_badge(item, icons, palette, count)
+	item:set({
+		label = { string = tostring(count) },
+		icon = (count > 0) and { color = palette.colors.red, string = icons.notifications.notif }
+			or { color = palette.colors.blue, string = icons.notifications.empty },
+	})
+end
+
+local function update(item, key_path, icons, palette)
+	return function(env)
+		sbar.exec(search_command(key_path, config.git_pr_query), function(result)
+			if type(result) ~= "table" or result.total_count == nil then
+				log("notifs", "[error] unexpected PR search response: " .. dump(result))
 				return
 			end
 
-			local count = 0
-			for _, _ in pairs(result) do
-				count = count + 1
-			end
-
-			item:set({
-				label = { string = tostring(count) },
-				icon = (count > 0) and { color = palette.colors.red, string = icons.notifications.notif }
-					or { color = palette.colors.blue, string = icons.notifications.empty },
-			})
+			set_badge(item, icons, palette, result.total_count)
 		end)
+
+		-- Future: fold open-issue count into the same badge. Left disabled since
+		-- issues aren't part of the day-to-day workflow on personal repos; flip on
+		-- once that changes (e.g. triaging issues on the homelab Gitea/GHE instance).
+		-- Requires combining both counts before a single item:set to avoid the two
+		-- async responses stomping each other's label.
+		--
+		-- local issue_query = "is:issue is:open assignee:@me"
+		-- sbar.exec(search_command(key_path, issue_query), function(result)
+		-- 	if type(result) ~= "table" or result.total_count == nil then
+		-- 		log("notifs", "[error] unexpected issue search response: " .. dump(result))
+		-- 		return
+		-- 	end
+		-- 	-- combine with the PR total_count above and set_badge() once
+		-- end)
 	end
 end
 
@@ -51,7 +78,7 @@ function mod.load(icons, palette)
 		mod.item = sbar.add("item", mod.properties)
 		mod.item:subscribe({ "routine", "forced" }, update(mod.item, config.git_key, icons, palette))
 		mod.item:subscribe("mouse.clicked", function()
-			sbar.exec("open https://github.com/notifications")
+			sbar.exec("open " .. config.git_web_url .. "/pulls/inbox")
 		end)
 	end
 


### PR DESCRIPTION
## Summary
- \`notifs.lua\` never loaded: \`config.git_key\` defaulted to \`nil\` with no local override setting it.
- Even with a key, \`update()\` assumed \`sbar.exec\`'s callback receives \`(result, exit_code)\`. SbarLua only ever passes one argument (\`result\`, auto-JSON-decoded), so \`exit_code\` was always \`nil\` and \`exit_code ~= 0\` short-circuited the handler on every single poll.
- Reworked from "unread notification count" (\`GET /notifications\`) to an aggregated open-PR badge via the search API (\`is:pr is:open author:@me\`). Click opens the PR inbox instead of the notifications page.
- Added \`config.git_api_url\` / \`config.git_web_url\` so this can point at a self-hosted GitHub Enterprise/Gitea instance (homelab) later, defaulting to github.com.
- Stubbed (commented) an open-issues query for future use — not part of the day-to-day workflow on personal repos today.

## Test plan
- [x] \`luac -p\` on all changed files
- [x] Ran the exact generated \`curl\` command against the real token; confirmed \`total_count\` in the JSON response
- [x] Restarted the live sketchybar LaunchAgent; \`sketchybar.out.log\` shows clean \`[lua-main] Finished loading\` with no notifs-related Lua errors
- [x] This very PR is the live functional test — once open, the badge should read at least \`1\`

Generated with Claude Code