### PR TITLE
feat(shell): integrate atuin shell history across bash/zsh/fish

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -11,3 +11,6 @@ if [[ $(ps --no-header --pid=$PPID --format=comm) != "fish" && -z ${BASH_EXECUTI
 fi
 
 eval "$(starship init bash)"
+
+. "$HOME/.atuin/bin/env"
+eval "$(atuin init bash)"

--- a/.zshrc
+++ b/.zshrc
@@ -267,3 +267,5 @@ eval "$(deja init zsh)"
 
 fpath=(/Users/fox/.zsh/completions $fpath)
 autoload -Uz compinit && compinit
+
+. "$HOME/.atuin/bin/env"

--- a/fish/conf.d/atuin.env.fish
+++ b/fish/conf.d/atuin.env.fish
@@ -1,0 +1,2 @@
+
+source "$HOME/.atuin/bin/env.fish"

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -93,3 +93,7 @@ end
 # Added by OrbStack: command-line tools and integration
 # This won't be added again if you remove it.
 source ~/.orbstack/shell/init2.fish 2>/dev/null || :
+
+if status is-interactive
+    atuin init fish | source
+end


### PR DESCRIPTION
Sources atuin's env script and init hooks in `.bashrc`, `.zshrc`, and `fish/config.fish`, plus a new `fish/conf.d/atuin.env.fish` for fish's env sourcing.