### PR TITLE
feat(theme): switch terminal palette to Catppuccin Mocha

### DIFF
--- a/kitty/dark-theme.auto.conf
+++ b/kitty/dark-theme.auto.conf
@@ -1,0 +1,81 @@
+## name:     Catppuccin Mocha 🌿
+## author:   Pocco81 (https://github.com/Pocco81)
+## license:  MIT
+## upstream: https://github.com/catppuccin/kitty/blob/main/mocha.conf
+## blurb:    Soothing pastel theme for the high-spirited!
+
+
+
+# The basic colors
+foreground              #CDD6F4
+background              #111419
+selection_foreground    #1E1E2E
+selection_background    #F5E0DC
+
+# Cursor colors
+cursor                  #8E95B3
+cursor_text_color       #1E1E2E
+
+cursor_shape underline
+cursor_shape_unfocused hollow
+
+# URL underline color when hovering with mouse
+url_color               #B4BEFE
+
+# Kitty window border colors
+active_border_color     #CBA6F7
+inactive_border_color   #8E95B3
+bell_border_color       #EBA0AC
+
+# OS Window titlebar colors
+wayland_titlebar_color system
+macos_titlebar_color system
+
+# Tab bar colors
+active_tab_foreground   #11111B
+active_tab_background   #CBA6F7
+inactive_tab_foreground #CDD6F4
+inactive_tab_background #181825
+tab_bar_background      #11111B
+
+# Colors for marks (marked text in the terminal)
+mark1_foreground #1E1E2E
+mark1_background #87B0F9
+mark2_foreground #1E1E2E
+mark2_background #CBA6F7
+mark3_foreground #1E1E2E
+mark3_background #74C7EC
+
+# The 16 terminal colors
+
+# black
+color0 #43465A
+color8 #43465A
+
+# red
+color1 #F38BA8
+color9 #F38BA8
+
+# green
+color2  #A6E3A1
+color10 #A6E3A1
+
+# yellow
+color3  #F9E2AF
+color11 #F9E2AF
+
+# blue
+color4  #87B0F9
+color12 #87B0F9
+
+# magenta
+color5  #F5C2E7
+color13 #F5C2E7
+
+# cyan
+color6  #94E2D5
+color14 #94E2D5
+
+# white
+color7  #CDD6F4
+color15 #A1A8C9

--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -35,10 +35,13 @@ cursor_stop_blinking_after 15.0
 # Cursor trail to be able to follow the cursor for easier readability
 cursor_trail 1
 
+# Hide mouse while typing
+mouse_hide_wait	-3.0
+
 # Window padding
 window_padding_width 10
 
-include ./themes/rose-pine.conf
+include ./themes/catppuccin_mocha.conf
 
 # Set transparent background and blur background
 background_opacity 0.60
@@ -52,7 +55,7 @@ hide_window_decorations titlebar-only
 
 #: Terminal Bell {{{
 
-enable_audio_bell     no
+enable_audio_bell     yes
 bell_on_tab           no
 
 #: }}}

--- a/kitty/light-theme.auto.conf
+++ b/kitty/light-theme.auto.conf
@@ -1,0 +1,51 @@
+# vim:ft=kitty
+
+## name: Adwaita light
+## author: Emil Löfquist (https://github.com/ewal)
+## license: MIT
+## upstream: https://github.com/ewal/kitty-adwaita/blob/main/adwaita_light.conf
+## blurb: Adwaita light - based on https://github.com/Mofiqul/adwaita.nvim
+
+background                #fcfcfc
+foreground                #504e55
+
+selection_background      #deddda
+selection_foreground      #5e5c64
+
+url_color                 #1a5fb4
+
+wayland_titlebar_color    system
+macos_titlebar_color      system
+
+cursor                    #504e55
+cursor_text_color         #fcfcfc
+
+active_border_color       #c0bfbc
+inactive_border_color     #f6f5f4
+bell_border_color         #ed333b
+visual_bell_color         none
+
+active_tab_background     #b0afac
+active_tab_foreground     #504e55
+inactive_tab_background   #deddda
+inactive_tab_foreground   #5e5c64
+tab_bar_background        none
+tab_bar_margin_color      none
+
+color0                    #fcfcfc
+color1                    #ed333b
+color2                    #57e389
+color3                    #ff7800
+color4                    #62a0ea
+color5                    #9141ac
+color6                    #5bc8af
+color7                    #deddda
+
+color8                    #9a9996
+color9                    #f66151
+color10                   #8ff0a4
+color11                   #ffa348
+color12                   #99c1f1
+color13                   #dc8add
+color14                   #93ddc2
+color15                   #f6f5f4

--- a/kitty/themes/terafox.conf
+++ b/kitty/themes/terafox.conf
@@ -1,0 +1,104 @@
+# vim:ft=kitty
+## name: Terafox
+## author: EdenEast
+## license: MIT
+## upstream: https://github.com/EdenEast/nightfox.nvim/blob/main/extra/terafox/kitty.conf
+## blurb: Terafox theme from the neovim colorscheme nightfox.nvim.
+
+#: All the settings below are colors, which you can choose to modify, or use the
+#: defaults. You can also add non-color based settings if needed but note that
+#: these will not work with using kitty @ set-colors with this theme. For a
+#: reference on what these settings do see https://sw.kovidgoyal.net/kitty/conf/
+
+#: The basic colors
+
+foreground                      #e6eaea
+background                      #152528
+selection_foreground            #e6eaea
+selection_background            #293e40
+
+
+#: Cursor colors
+
+cursor                          #e6eaea
+cursor_text_color               #152528
+
+
+#: URL underline color when hovering with mouse
+
+url_color                       #7aa4a1
+
+
+#: kitty window border colors and terminal bell colors
+
+active_border_color             #5a93aa
+inactive_border_color           #2d4f56
+bell_border_color               #ff8349
+# visual_bell_color               none
+
+
+#: OS Window titlebar colors
+
+# wayland_titlebar_color          system
+# macos_titlebar_color            system
+
+
+#: Tab bar colors
+
+active_tab_foreground           #0f1c1e
+active_tab_background           #5a93aa
+inactive_tab_foreground         #6d7f8b
+inactive_tab_background         #293e40
+# tab_bar_background              none
+# tab_bar_margin_color            none
+
+
+#: Colors for marks (marked text in the terminal)
+
+# mark1_foreground black
+# mark1_background #98d3cb
+# mark2_foreground black
+# mark2_background #f2dcd3
+# mark3_foreground black
+# mark3_background #f274bc
+
+
+#: The basic 16 colors
+
+#: black
+color0 #2f3239
+color8 #4e5157
+
+#: red
+color1 #e85c51
+color9 #eb746b
+
+#: green
+color2  #7aa4a1
+color10 #8eb2af
+
+#: yellow
+color3  #fda47f
+color11 #fdb292
+
+#: blue
+color4  #5a93aa
+color12 #73a3b7
+
+#: magenta
+color5  #ad5c7c
+color13 #b97490
+
+#: cyan
+color6  #a1cdd8
+color14 #afd4de
+
+#: white
+color7  #ebebeb
+color15 #eeeeee
+
+
+#: You can set the remaining 240 colors as color16 to color255.
+
+color16 #ff8349
+color17 #cb7985

--- a/starship.toml
+++ b/starship.toml
@@ -26,12 +26,12 @@ $git_metrics\
 
 right_format = """$aws$python$docker_context$terraform"""
 
-palette = "rose_pine"
+palette = "catppuccin_mocha"
 
 [character]
 disabled = false
-# success_symbol = "[ ](bold fg:text)"
-success_symbol = "[󰌪 ](bold fg:green)"
+success_symbol = "[ ](bold fg:text)"
+# success_symbol = "[󰌪 ](bold fg:green)"
 error_symbol = "[✘](red bold)"
 vimcmd_symbol = "[: ](bold fg:yellow)"
 vimcmd_replace_one_symbol = '[󰜉 ](bold fg:maroon)'

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -122,10 +122,10 @@ config = {
 
 	-- For example, changing the color scheme:
 	-- color_scheme = "Catppuccin Frappé (Gogh)",
-	-- color_scheme = "Catppuccin Mocha (Gogh)",
+	color_scheme = "Catppuccin Mocha (Gogh)",
 	-- color_scheme = "Catppuccin Latte (Gogh)",
 	-- color_scheme = "Rosé Pine Moon (Gogh)",
-	color_scheme = "Rosé Pine (Gogh)",
+	-- color_scheme = "Rosé Pine (Gogh)",
 
 	-- Removes the macos bar at the top with the 3 buttons
 	window_decorations = "RESIZE",


### PR DESCRIPTION
- kitty: active theme -> catppuccin_mocha, audio bell on, hide mouse while typing
- kitty: add dark/light auto themes and Terafox theme to the library
- starship: palette -> catppuccin_mocha, restore plain success symbol
- wezterm: active color_scheme -> Catppuccin Mocha (Gogh)